### PR TITLE
🛠️ Refactor: Extract MetadataDumper and enforce conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Agent Guidelines
+
+## Conventions
+
+- **Mise First**: `mise` is non-negotiable for all task execution.
+- **Centralized Error Reporting**: All unexpected errors must be funneled through `src/errorReporter.ts`.
+- **Directory Structure**: Source code belongs in `src/`.
+- **Single Responsibility Principle**: Ensure each class/module handles a single responsibility (e.g. separate business logic like metadata generation from the Obsidian plugin UI/lifecycle).
+
+## Where To Find Things
+- `main.ts` -> Plugin entrypoint and lifecycle events.
+- `src/MetadataDumper.ts` -> Core logic for metadata processing and chunking.
+- `src/errorReporter.ts` -> Centralized error reporting for the plugin.
+- `rollup.config.mjs` -> Plugin build configuration.
+- `.github/workflows/` -> CI / CD pipelines.

--- a/main.ts
+++ b/main.ts
@@ -1,96 +1,32 @@
-import { Notice, Plugin } from 'obsidian';
+import { Plugin } from 'obsidian';
+import { MetadataDumper } from './src/MetadataDumper';
+import { reportError } from './src/errorReporter';
 
-const FILENAME = "meta.json";
-
-interface Item {
-	basename: string,
-	extension: string,
-	name: string,
-	path: string,
-	ctime: number,
-	mtime: number
-}
-
+const DUMP_INTERVAL_MS = 1000 * 300;
 
 export default class Dumper extends Plugin {
-	normalizeItem(item: Object) {
-		const {
-			basename,
-			extension,
-			name,
-			path,
-			stat: {
-				ctime,
-				mtime
-			}
-		} = item as any
-		const backlinks = (this.app.metadataCache as any).getBacklinksForFile(item).data
-		const backlinkFiles = Object.keys(backlinks)
-		return {
-			basename,
-			extension,
-			name,
-			path,
-			ctime,
-			mtime,
-			referencedBy: backlinkFiles
-		} as Item
-	}
-	async dumpMetadata() {
-		console.log("dumping...")
-		// TODO: assert this is happening only once concurrently
-		const input = (this.app.vault as any).fileMap
-		let ret : Record<string, Item> = {}
-		const promises = Object.keys(input).map((key) => {
-			return new Promise<void>((res) => {
-				setTimeout(() => { // WORKAROUND: don't freeze the main thread while dumping stuff. Good for big (>1k notes) vaults
-					try { // folders does not provide stat so normalizeItem will fail
-						if (key === "meta.json") {
-							throw null // just to finally
-						}
-						const value = input[key]
-						const normalizedValue = this.normalizeItem(value)
-						let shortKey = normalizedValue.basename
-						let longKey = normalizedValue.path
-						if (normalizedValue.extension === "md") {
-							longKey = longKey.slice(0, longKey.length - normalizedValue.extension.length - 1)
-						}
-						ret[longKey] = normalizedValue
-						if (ret[shortKey] === undefined || ret[shortKey].path.split("/").length > normalizedValue.path.split("/").length) {
-							ret[shortKey] = normalizedValue
-						}
-					} 
-					catch {}
-					finally {
-						res()
-					}
-				}, 1)
-			})
-		})
-		try {
-			await Promise.all(promises)
-			const data = JSON.stringify(ret, null, 2)
-			await this.app.vault.adapter.write(FILENAME, data)
-		} catch(e) {
-			new Notice("Failed to dump metadata. Press Ctrl+Shift+i for details.")
-			console.error(e)
-		} finally {
-			console.log("metadump success")
-		}
-	}
+	private dumper: MetadataDumper;
 
 	async onload() {
 		console.log('started dumping metadata');
+
+		this.dumper = new MetadataDumper(this.app);
 
 		this.addCommand({
 			id: 'dump-metadata',
 			name: 'Dump metadata file',
 			callback: () => {
-				this.dumpMetadata()
+				this.dumper.dumpMetadata().catch(e => {
+					reportError("Failed command execution for dumpMetadata", e);
+				});
 			},
 		});
 
-		this.registerInterval(window.setInterval(() => this.dumpMetadata(), 1000 * 300)) // 5 minutes
+		this.registerInterval(window.setInterval(() => {
+			this.dumper.dumpMetadata().catch(e => {
+				reportError("Failed interval execution for dumpMetadata", e);
+			});
+		}, DUMP_INTERVAL_MS));
 	}
 
 	onunload() {

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,9 @@
+[tools]
+node = "22.0.0"
+
+[tasks."install:*"]
+run = "npm install"
+
+[tasks."ci:*"]
+depends = ["install:*"]
+run = "npm run build"

--- a/src/MetadataDumper.ts
+++ b/src/MetadataDumper.ts
@@ -1,0 +1,94 @@
+import { App, Notice } from 'obsidian';
+import { reportError } from './errorReporter';
+
+export interface Item {
+	basename: string,
+	extension: string,
+	name: string,
+	path: string,
+	ctime: number,
+	mtime: number,
+	referencedBy?: string[]
+}
+
+const YIELD_DELAY_MS = 1;
+const FILENAME = "meta.json";
+
+export class MetadataDumper {
+	private app: App;
+
+	constructor(app: App) {
+		this.app = app;
+	}
+
+	normalizeItem(item: Object): Item {
+		const {
+			basename,
+			extension,
+			name,
+			path,
+			stat: {
+				ctime,
+				mtime
+			}
+		} = item as any
+		const backlinks = (this.app.metadataCache as any).getBacklinksForFile(item).data
+		const backlinkFiles = Object.keys(backlinks)
+		return {
+			basename,
+			extension,
+			name,
+			path,
+			ctime,
+			mtime,
+			referencedBy: backlinkFiles
+		} as Item
+	}
+
+	async dumpMetadata() {
+		console.log("dumping...")
+		// TODO: assert this is happening only once concurrently
+		const input = (this.app.vault as any).fileMap
+		let ret : Record<string, Item> = {}
+		const promises = Object.keys(input).map((key) => {
+			return new Promise<void>((res) => {
+				setTimeout(() => { // WORKAROUND: don't freeze the main thread while dumping stuff. Good for big (>1k notes) vaults
+					try { // folders does not provide stat so normalizeItem will fail
+						if (key === "meta.json") {
+							throw null // just to finally
+						}
+						const value = input[key]
+						const normalizedValue = this.normalizeItem(value)
+						let shortKey = normalizedValue.basename
+						let longKey = normalizedValue.path
+						if (normalizedValue.extension === "md") {
+							longKey = longKey.slice(0, longKey.length - normalizedValue.extension.length - 1)
+						}
+						ret[longKey] = normalizedValue
+						if (ret[shortKey] === undefined || ret[shortKey].path.split("/").length > normalizedValue.path.split("/").length) {
+							ret[shortKey] = normalizedValue
+						}
+					}
+					catch(e) {
+						if (e !== null) {
+							reportError(`Failed to normalize item for key ${key}`, e);
+						}
+					}
+					finally {
+						res()
+					}
+				}, YIELD_DELAY_MS)
+			})
+		})
+		try {
+			await Promise.all(promises)
+			const data = JSON.stringify(ret, null, 2)
+			await this.app.vault.adapter.write(FILENAME, data)
+		} catch(e) {
+			new Notice("Failed to dump metadata. Press Ctrl+Shift+i for details.")
+			reportError("Failed to write metadata file", e);
+		} finally {
+			console.log("metadump success")
+		}
+	}
+}

--- a/src/errorReporter.ts
+++ b/src/errorReporter.ts
@@ -1,0 +1,9 @@
+/**
+ * Centralized error reporting function.
+ * All unexpected errors must be funneled through this function.
+ *
+ * If Sentry is set up in the future, this is where it should be integrated.
+ */
+export function reportError(message: string, error?: any) {
+	console.error(`[Error] ${message}`, error ? error : '');
+}


### PR DESCRIPTION
## Overview
This PR improves the internal structure, reliability, and convention-adherence of the `obsidian-metadump` plugin without altering its core external behavior.

## Changes
- **Extracted Core Logic:** Moved the complex `dumpMetadata` process and chunking logic into a dedicated `MetadataDumper` class under `src/`. This adheres to the Single Responsibility Principle, separating the business logic from the Obsidian `Plugin` infrastructure.
- **Removed Magic Numbers:** Replaced hardcoded timeout delays (`1`) and interval multipliers (`1000 * 300`) with named constants (`YIELD_DELAY_MS`, `DUMP_INTERVAL_MS`).
- **Centralized Error Reporting:** Created `src/errorReporter.ts`. All previously swallowed errors (e.g. within `.catch()` or `catch {}` blocks) are now safely logged using this centralized function.
- **Agent Conventions Documented:** Added an `AGENTS.md` file to formally codify guidelines for repository interaction, layout, and tooling requirements (`mise`).
- **Tooling:** Pinned project tools and baseline tasks explicitly in a `mise.toml` configuration file.

## Assumptions
- I assumed the `throw null` workaround in the original code for `meta.json` handling was intentional and specifically filtered `null` errors from being reported to the new centralized error reporting function.
- Assumed it is safe to create `src/` directory directly alongside `main.ts` since it does not disrupt the Rollup build output.

## Alternatives Not Chosen
- **Extracting Interfaces to `types.ts`:** Decided to keep the `Item` interface directly inside `MetadataDumper.ts` due to its high cohesion with the dumping logic. 

## How To Pivot
If the `MetadataDumper` logic should still reside in `main.ts` as a helper function rather than an instantiated class, it can be reverted and refactored into a stateless exported function.

## Next Knobs
- **Sentry Integration:** The `reportError` function can now easily be wired up to Sentry or another telemetry service by modifying a single location.
- **Rollup Source Output:** You might consider adjusting `rollup.config.mjs` to output compiled `src/` modules securely if you introduce deep imports, although TypeScript handles the current flat mapping correctly.

---
*PR created automatically by Jules for task [18257965724252074816](https://jules.google.com/task/18257965724252074816) started by @lucasew*