### PR TITLE
📝 Docs: Document main plugin logic and conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Project Conventions for AI Agents
+
+## General Instructions
+* **Mise First:** `mise` is non-negotiable for task execution. Pin `mise` tools to specific versions.
+* **Error Handling:** Never ignore errors or leave empty catch blocks. All unexpected errors MUST be funneled through a centralized error-reporting function (e.g., `reportError`), integrating with Sentry if available.
+* **Code Structure:**
+  * Source code resides in the `src/` directory.
+  * `src/main.ts` is the Obsidian plugin entrypoint. It should primarily handle plugin UI/lifecycle events.
+  * Follow the Single Responsibility Principle: decoupled business logic (like `MetadataDumper` or `errorReporter.ts`) should be separated into their own modules within `src/`.
+* **Testing:** Ensure automated checks pass, then perform a manual sanity check reasoning through runtime behavior. Tests must exercise your actual implementation.
+* **Dependency Management:** Never downgrade dependencies unless explicitly requested. Do not commit downloaded binaries, tooling artifacts, or `install-mise.sh`.
+* **GitHub Actions:** Restricted to exactly ONE workflow file (`.github/workflows/autorelease.yml`) executing all pipeline steps.
+
+## Build and Tooling
+* The project uses **Rollup** for builds (`rollup.config.mjs`). Entrypoint is `src/main.ts`.
+* Compiled files output to `dist/`, with `rollup-plugin-copy` moving `main.js` back to the root for Obsidian.
+* Build command: `npm run build`
+* All linting and formatting MUST use `workspaced` via `mise`. Do not manually install linters.
+* All `mise` tasks (`lint`, `fmt`, `test`, `codegen`, `install`, `ci`) should depend ONLY on wildcards if needed.
+
+## PR Conventions
+* **Docs Agent:** PR Title must be exactly `📝 Docs: [Description]`. Execution is strictly restricted to documentation (no logic changes). Scope to one cohesive area, max 10 files / 280 lines.
+* **Refactor Agent:** PR Title must be exactly `🛠️ Refactor: [Description]`.
+* **Sentinel Agent:** Must append a single-line journal entry in `.jules/sentinel.md` formatted as `- YYYY-MM-DD: [the class of issue and how to spot it]`.
+* **PR Body:** Every PR MUST include four concise sections: `Assumptions`, `Alternatives Not Chosen`, `How To Pivot`, and `Next Knobs`.
+
+## Git Operations
+* Never use `git add -A` or `git add .`. Stage files explicitly using `git add <path>`.
+
+## Discoverability (Where To Find Things)
+* `main.ts` -> Obsidian plugin lifecycle and UI integration (currently in root, to be moved to `src/`)
+* `rollup.config.mjs` -> Build configuration
+* `package.json` -> Dependencies and scripts

--- a/main.ts
+++ b/main.ts
@@ -2,6 +2,11 @@ import { Notice, Plugin } from 'obsidian';
 
 const FILENAME = "meta.json";
 
+/**
+ * Represents the normalized metadata for a single entity in the vault.
+ * Extracted by external tools or personal automations to build offline graphs
+ * without needing to parse the markdown contents directly.
+ */
 interface Item {
 	basename: string,
 	extension: string,
@@ -12,7 +17,23 @@ interface Item {
 }
 
 
+/**
+ * Main Obsidian plugin entrypoint. Orchestrates periodic extraction of the vault's
+ * file metadata and backlink graph, persisting it to a unified JSON file.
+ * This decoupled approach allows separate external scripts to consume the vault
+ * state reliably.
+ */
 export default class Dumper extends Plugin {
+	/**
+	 * Transforms an internal Obsidian file object into a standardized `Item` format,
+	 * enriching it with resolved backlinks from the global `metadataCache`.
+	 *
+	 * @param item - Raw Obsidian file/folder object from the internal `fileMap`.
+	 * @returns The structured metadata, including a dynamically injected `referencedBy` array.
+	 *
+	 * @throws Will fail silently (caught by caller) if the item is a folder, as folders
+	 * lack the required `stat` (ctime/mtime) properties.
+	 */
 	normalizeItem(item: Object) {
 		const {
 			basename,
@@ -36,6 +57,22 @@ export default class Dumper extends Plugin {
 			referencedBy: backlinkFiles
 		} as Item
 	}
+	/**
+	 * Asynchronously scans the entire vault and serializes the metadata graph to disk.
+	 *
+	 * **Performance considerations:**
+	 * To prevent freezing the Obsidian UI on large vaults (>1k notes), the iteration
+	 * is chunked using `setTimeout(..., 1)`. This macro-task scheduling yields the main
+	 * thread between processing each file.
+	 *
+	 * **Edge Cases handled:**
+	 * - Skips the target `meta.json` file to prevent recursive processing.
+	 * - Gracefully handles and ignores folders (via try/catch around `normalizeItem`).
+	 * - Deduplicates entries by prioritizing the shortest path when filenames collide.
+	 *
+	 * **Side Effects:**
+	 * Overwrites `meta.json` in the root of the vault. Spawns a UI `Notice` if the write fails.
+	 */
 	async dumpMetadata() {
 		console.log("dumping...")
 		// TODO: assert this is happening only once concurrently
@@ -79,6 +116,11 @@ export default class Dumper extends Plugin {
 		}
 	}
 
+	/**
+	 * Bootstraps the plugin lifecycle upon activation.
+	 * Registers a manual command palette trigger and establishes a 5-minute
+	 * background polling interval to keep the JSON graph eventually consistent.
+	 */
 	async onload() {
 		console.log('started dumping metadata');
 
@@ -93,6 +135,10 @@ export default class Dumper extends Plugin {
 		this.registerInterval(window.setInterval(() => this.dumpMetadata(), 1000 * 300)) // 5 minutes
 	}
 
+	/**
+	 * Lifecycle hook called when the plugin is disabled or Obsidian is closing.
+	 * (Note: Intervals registered via `registerInterval` are automatically cleaned up by Obsidian).
+	 */
 	onunload() {
 		console.log('stopped dumping metadata');
 	}


### PR DESCRIPTION
Added comprehensive JSDoc comments to `main.ts` explaining the `Item` interface and `Dumper` class methods, including performance nuances (e.g., yielding the main thread) and edge cases. Also scaffolded `AGENTS.md` to consolidate implicit repository conventions.

### Assumptions
- The primary entrypoint is `main.ts`, which currently houses both the Obsidian UI lifecycle and the `MetadataDumper` logic, making it the most critical file to document first.
- There was no pre-existing `CLAUDE.md` or `AGENTS.md`, so a new `AGENTS.md` was created as the single source of truth to codify the instructions provided in the context memory.

### Alternatives Not Chosen
- Did not document `rollup.config.mjs` or `package.json` as the PR scope was strictly focused on one cohesive area (`main.ts` and the repository conventions file).
- Did not refactor the code to move `main.ts` into `src/` or extract the `Dumper` class, as the "Docs" agent's operational contract strictly prohibits changing executable logic or project structure.

### How To Pivot
- To change the JSDoc style or detail level, modify the comments within `main.ts` directly.
- To adjust the documented repository rules, edit the contents of `AGENTS.md`.

### Next Knobs
- The `src/` directory migration and `errorReporter` implementation (mentioned in conventions) are pending tasks for a Refactor/Sentinel agent.
- Additional documentation can be targeted at specific helper functions or configuration files in future Docs PRs.

---
*PR created automatically by Jules for task [9298257662035883002](https://jules.google.com/task/9298257662035883002) started by @lucasew*